### PR TITLE
update playlist.py

### DIFF
--- a/pytube/contrib/playlist.py
+++ b/pytube/contrib/playlist.py
@@ -143,8 +143,8 @@ class Playlist(Sequence):
         """
         yield from (YouTube(url) for url in self.video_urls)
 
-    def __getitem__(self, i: Union[slice, int]) -> Union[str, List[str]]:
-        return self.video_urls[i]
+    def __getitem__(self, i: Union[slice, int]) -> Union[YouTube, List[YouTube]]:
+        return YouTube(self.video_urls[i])
 
     def __len__(self) -> int:
         return len(self.video_urls)


### PR DESCRIPTION
"Playlist" isn't working properly. According to pytube3 documentation (https://pypi.org/project/pytube3/), we are supposed to get a list of "YouTube" objects for youtube playlist video URLs from "playlist" object instead of a list of playlist video URLs as strings. Screenshot of documentation is shown below:
![Screenshot from 2020-06-05 13-15-02](https://user-images.githubusercontent.com/35453959/83848163-4324ad00-a72f-11ea-8fd6-df39306b1052.png)

I have made a little modification and now it's working fine. If you are happy with my solution, then please accept this pull request............
