### PR TITLE
fix for cipher error

### DIFF
--- a/pytube/extract.py
+++ b/pytube/extract.py
@@ -297,9 +297,14 @@ def apply_descrambler(stream_data: Dict, key: str) -> None:
                 for format_item in formats
             ]
         except KeyError:
-            cipher_url = [
-                parse_qs(formats[i]["cipher"]) for i, data in enumerate(formats)
-            ]
+            try:
+                cipher_url = [
+                    parse_qs(formats[i]["cipher"]) for i, data in enumerate(formats)
+                ]
+            except KeyError:
+                cipher_url = [
+                    parse_qs(formats[i]["signatureCipher"]) for i, data in enumerate(formats)
+                ]
             stream_data[key] = [
                 {
                     "url": cipher_url[i]["url"][0],


### PR DESCRIPTION
The key is sometimes given as cipher, sometimes as signatureCipher. Code fails to execute properly if it only looks for cipher so additional check for signatureCipher added to fall back on.