### PR TITLE
Naive fix for Playlist returns empty list

### DIFF
--- a/pytube/contrib/playlist.py
+++ b/pytube/contrib/playlist.py
@@ -42,7 +42,7 @@ class Playlist(Sequence):
                 f"{month} {day:0>2} {year}", "%b %d %Y"
             ).date()
 
-        self._video_regex = re.compile(r"href=\"(/watch\?v=[\w-]*)")
+        self._video_regex = re.compile(r"\"url\":\"(/watch\?v=[\w-]*)")
 
     @staticmethod
     def _find_load_more_url(req: str) -> Optional[str]:


### PR DESCRIPTION
YouTube has updated their links on playlist web pages from an href tag to a JSON object. Changed the `_video_regex` to match.